### PR TITLE
Optimizes arrays smaller than limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/async",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Async loops for ES2017",
   "main": "src/async.js",
   "files": [

--- a/src/async.js
+++ b/src/async.js
@@ -13,7 +13,7 @@ function asyncArrayMap(array, callback, limit = 0){
 	let result;
 	if (Array.isArray(array) && (typeof callback === 'function') && (typeof limit === 'number') && !isNaN(limit)){
 		let promises = [];
-		if (limit > 0){
+		if ((limit > 0) && (limit < array.length)){
 			const helper = pLimit(limit);
 			promises = array.map((value, index, arrayRef) => helper(() => callback(value, index, arrayRef)));
 		} else {


### PR DESCRIPTION
Skips needlessly tracking simultaneous promises in `asyncArrayMap` if the array is already smaller than the limit because it's the same as if there was no constraint on it.